### PR TITLE
Fix subscription API parameters

### DIFF
--- a/components/subscription/subscription-modal.tsx
+++ b/components/subscription/subscription-modal.tsx
@@ -34,8 +34,8 @@ export default function SubscriptionModal({ isOpen, onClose, currentPlan, userId
         body: JSON.stringify({
           planId: plan.id,
           userId: userId,
-          successUrl: `${window.location.origin}/dashboard?subscription=success`,
-          cancelUrl: `${window.location.origin}/dashboard?subscription=canceled`,
+          successUrl: `${window.location.origin}/dashboard/profile?subscription=success`,
+          cancelUrl: `${window.location.origin}/dashboard/profile?subscription=canceled`,
         }),
       })
 

--- a/subscription-modal.tsx
+++ b/subscription-modal.tsx
@@ -26,8 +26,9 @@ export default function SubscriptionModal({ isOpen, onClose, currentPlan, userId
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
-          priceId: `price_${plan.id}`, // In a real app, this would be a real Stripe price ID
-          customerId: userId,
+          // The API expects the plan ID and user ID
+          planId: plan.id,
+          userId,
           successUrl: `${window.location.origin}/dashboard/profile?subscription=success`,
           cancelUrl: `${window.location.origin}/dashboard/profile?subscription=canceled`,
         }),


### PR DESCRIPTION
## Summary
- send `planId` and `userId` when creating checkout sessions
- fix checkout redirect paths

## Testing
- `npx tsc --noEmit` *(fails: cannot find modules)*